### PR TITLE
Fix syntax formatting in JavaScript.md

### DIFF
--- a/content/Programming/Frontend/JS/0 - JavaScript.md
+++ b/content/Programming/Frontend/JS/0 - JavaScript.md
@@ -32,7 +32,7 @@ delete or `splice` from array
 
 Both `i++` as well as `i+=` is allowed in Javascript. 
 `return` works the same as Python.
-Use`//` for inline comment and `/* shizle goes here */` for comment snippet
+Use `//` for inline comment and `/* shizle goes here */` for comment snippet
 
 Check [[Functions]] for overview and syntax for functions.
 Check [[Control Flow]] for notes on loops and conditionals.


### PR DESCRIPTION
Added a missing space between two words. 

Changes:
> Use`//` for inline comment and `/* shizle goes here */` for comment snippet

to

> Use `//` for inline comment and `/* shizle goes here */` for comment snippet